### PR TITLE
refactor code, add directory cleanup and tests

### DIFF
--- a/src/LaravelCacheGarbageCollector.php
+++ b/src/LaravelCacheGarbageCollector.php
@@ -2,10 +2,8 @@
 
 namespace jdavidbakr\LaravelCacheGarbageCollector;
 
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -29,25 +27,22 @@ class LaravelCacheGarbageCollector extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         // Make a storage disk for the cache location
         $cacheDisk = [
-            'driver'=>'local',
-            'root'=>config('cache.stores.file.path')
+            'driver' => 'local',
+            'root' => config('cache.stores.file.path')
         ];
 
         Config::set('filesystems.disks.fcache', $cacheDisk);
 
-        $expired_file_count = 0;
-        $active_file_count = 0;
-
         // Grab the cache files
         $files = Storage::disk('fcache')->allFiles();
 
-        foreach ($files as $key=>$cachefile) {
+        foreach ($files as $cachefile) {
             if ($cachefile == '.gitignore') {
                 continue;
             }
@@ -58,18 +53,34 @@ class LaravelCacheGarbageCollector extends Command
                 // Get the expiration time
                 $expire = substr($contents, 0, 10);
 
-                if (Carbon::now()->timestamp >= $expire) {
-                    Storage::disk('fcache')->delete($cachefile);
-
-                    $expired_file_count++;
-
+                if (Carbon::now()->timestamp < $expire) {
                     continue;
                 }
 
-                $active_file_count++;
+                Storage::disk('fcache')->delete($cachefile);
             } catch (FileNotFoundException $e) {
                 continue;
             }
         }
+
+        // Now that we've removed expired files, grab all directories
+        $directories = Storage::disk('fcache')->allDirectories();
+
+        foreach ($directories as $directory) {
+            try {
+                $directoryFiles = Storage::disk('fcache')->allFiles($directory);
+
+                if (count($directoryFiles)) {
+                    // We still have cache files in this directory, we don't want to remove it
+                    continue;
+                }
+
+                Storage::disk('fcache')->deleteDirectory($directory);
+            } catch (FileNotFoundException $e) {
+                continue;
+            }
+        }
+
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Currently, the command cleans up expired cache files, but leaves the empty directories behind.
This PR ensures that empty directories are also cleaned up after purging expired cache entries.
I've also done a slight code refactor.